### PR TITLE
Fix GitHub Pages enablement in deployment workflow

### DIFF
--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This PR adds the enablement parameter to the configure-pages action to allow automatic GitHub Pages setup on the first deployment run.

## Changes
- Add `enablement: true` to the configure-pages action

## Testing
Once merged, the deployment workflow will automatically enable GitHub Pages if it's not already configured.